### PR TITLE
重构 IdentifyJavaClassType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# ignore eclipse config files
+# Ignore eclipse config files
 .classpath
 .project
 .settings/
+
+# Ignore build folder
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# ignore eclipse config files
+.classpath
+.project
+.settings/

--- a/cooper-util/src/main/java/jdepend/util/analyzer/element/IdentifyJavaClassType.java
+++ b/cooper-util/src/main/java/jdepend/util/analyzer/element/IdentifyJavaClassType.java
@@ -26,7 +26,7 @@ public class IdentifyJavaClassType extends AbstractAnalyzer {
 	protected void doSearch(AnalysisResult result) throws JDependException {
 		ServiceOrVO sov;
 		for (JavaClass javaClass : result.getClasses()) {
-			if (javaClass.isInner()) {
+			if (!javaClass.isInner()) {
 				continue;
 			}
 			

--- a/cooper-util/src/main/java/jdepend/util/analyzer/element/IdentifyJavaClassType.java
+++ b/cooper-util/src/main/java/jdepend/util/analyzer/element/IdentifyJavaClassType.java
@@ -32,83 +32,86 @@ public class IdentifyJavaClassType extends AbstractAnalyzer {
 			type = Unensure_TYPE;
 			ensure_VO_TYPE = false;
 			index = "";
+			
 			if (javaClass.isInner()) {
-				if (!javaClass.isState()) {
-					if (javaClass.getMethods().size() == 1 && javaClass.getMethods().iterator().next().isConstruction()) {
-						type = VO_TYPE;
-						index = "1";
-						ensure_VO_TYPE = true;
-					}
-					if (type.equals(Unensure_TYPE)) {
-						L1: for (JavaClass subClass : javaClass.getSubClasses()) {
-							if (subClass.isState()) {
-								type = VO_TYPE;
-								index = "2";
-								break L1;
-							}
-						}
-					}
-					if (type.equals(Unensure_TYPE)) {
-						L2: for (JavaClass superClass : javaClass.getSupers()) {
-							if (superClass.isState()) {
-								type = VO_TYPE;
-								index = "3";
-								break L2;
-							}
-						}
-					}
-					if (type.equals(Unensure_TYPE)) {
-						type = Service_TYPE;
-						index = "4";
-					}
-				} else {
+				continue;
+			}
+
+			if (!javaClass.isState()) {
+				if (javaClass.getMethods().size() == 1 && javaClass.getMethods().iterator().next().isConstruction()) {
 					type = VO_TYPE;
-					index = "5";
+					index = "1";
+					ensure_VO_TYPE = true;
+				}
+				if (type.equals(Unensure_TYPE)) {
+					L1: for (JavaClass subClass : javaClass.getSubClasses()) {
+						if (subClass.isState()) {
+							type = VO_TYPE;
+							index = "2";
+							break L1;
+						}
+					}
+				}
+				if (type.equals(Unensure_TYPE)) {
+					L2: for (JavaClass superClass : javaClass.getSupers()) {
+						if (superClass.isState()) {
+							type = VO_TYPE;
+							index = "3";
+							break L2;
+						}
+					}
+				}
+				if (type.equals(Unensure_TYPE)) {
+					type = Service_TYPE;
+					index = "4";
+				}
+			} else {
+				type = VO_TYPE;
+				index = "5";
+			}
+
+			if (type.equals(VO_TYPE) && !ensure_VO_TYPE) {
+
+				boolean haveBusinessMethod = false;
+				O: for (Method method : javaClass.getMethods()) {
+					if (!method.isConstruction() && !method.getName().startsWith("get")
+							&& !method.getName().startsWith("set")) {
+						haveBusinessMethod = true;
+						break O;
+					}
+				}
+				if (!haveBusinessMethod) {
+					type = VO_TYPE;
+					index += "6";
+					ensure_VO_TYPE = true;
 				}
 
-				if (type.equals(VO_TYPE) && !ensure_VO_TYPE) {
-
-					boolean haveBusinessMethod = false;
-					O: for (Method method : javaClass.getMethods()) {
-						if (!method.isConstruction() && !method.getName().startsWith("get")
-								&& !method.getName().startsWith("set")) {
-							haveBusinessMethod = true;
-							break O;
-						}
-					}
-					if (!haveBusinessMethod) {
-						type = VO_TYPE;
-						index += "6";
-						ensure_VO_TYPE = true;
-					}
-
-					if (!ensure_VO_TYPE) {
-						L1: for (JavaClass superClass : javaClass.getSupers()) {
-							if (superClass.isState()) {
-								type = VO_TYPE;
-								index += "7";
-								ensure_VO_TYPE = true;
-								break L1;
-							}
-						}
-					}
-
-					if (!ensure_VO_TYPE) {
-						boolean isParamRelation = false;
-						M: for (JavaClassRelationItem item : javaClass.getCaItems()) {
-							if (item.getType() instanceof ParamRelation) {
-								isParamRelation = true;
-								break M;
-							}
-						}
-						if (!isParamRelation) {
-							type = Service_TYPE;
-							index += "9";
-						} else {
+				if (!ensure_VO_TYPE) {
+					L1: for (JavaClass superClass : javaClass.getSupers()) {
+						if (superClass.isState()) {
 							type = VO_TYPE;
-							index += "10";
+							index += "7";
 							ensure_VO_TYPE = true;
+							break L1;
 						}
+					}
+				}
+
+				if (!ensure_VO_TYPE) {
+					boolean isParamRelation = false;
+					M: for (JavaClassRelationItem item : javaClass.getCaItems()) {
+						if (item.getType() instanceof ParamRelation) {
+							isParamRelation = true;
+							break M;
+						}
+					}
+					if (!isParamRelation) {
+						type = Service_TYPE;
+						index += "9";
+					} else {
+						type = VO_TYPE;
+						index += "10";
+						ensure_VO_TYPE = true;
 					}
 				}
 			}

--- a/cooper-util/src/main/java/jdepend/util/analyzer/element/IdentifyJavaClassType.java
+++ b/cooper-util/src/main/java/jdepend/util/analyzer/element/IdentifyJavaClassType.java
@@ -1,21 +1,22 @@
 package jdepend.util.analyzer.element;
 
+import java.util.Collection;
+
 import jdepend.framework.exception.JDependException;
 import jdepend.model.JavaClass;
 import jdepend.model.JavaClassRelationItem;
 import jdepend.model.Method;
 import jdepend.model.relationtype.ParamRelation;
 import jdepend.model.result.AnalysisResult;
+import jdepend.util.analyzer.element.helper.ServiceOrVO;
 import jdepend.util.analyzer.framework.AbstractAnalyzer;
 import jdepend.util.analyzer.framework.Analyzer;
+
+import static jdepend.util.analyzer.element.helper.ServiceOrVO.*;
 
 public class IdentifyJavaClassType extends AbstractAnalyzer {
 
 	private static final long serialVersionUID = 4752453696439145223L;
-
-	private final static String Service_TYPE = "Service";
-	private final static String VO_TYPE = "VO";
-	private final static String Unensure_TYPE = "不确定";
 
 	public IdentifyJavaClassType() {
 		super("识别JavaClass是Service还是VO", Analyzer.Attention, "识别JavaClass是Service还是VO");
@@ -23,102 +24,75 @@ public class IdentifyJavaClassType extends AbstractAnalyzer {
 
 	@Override
 	protected void doSearch(AnalysisResult result) throws JDependException {
-
-		String type;
-		boolean ensure_VO_TYPE;
-		String index;
-
+		ServiceOrVO sov;
 		for (JavaClass javaClass : result.getClasses()) {
-			type = Unensure_TYPE;
-			ensure_VO_TYPE = false;
-			index = "";
-			
 			if (javaClass.isInner()) {
 				continue;
 			}
-
+			sov = INIT;
 			if (!javaClass.isState()) {
 				if (javaClass.getMethods().size() == 1 && javaClass.getMethods().iterator().next().isConstruction()) {
-					type = VO_TYPE;
-					index = "1";
-					ensure_VO_TYPE = true;
-				}
-				if (type.equals(Unensure_TYPE)) {
-					L1: for (JavaClass subClass : javaClass.getSubClasses()) {
-						if (subClass.isState()) {
-							type = VO_TYPE;
-							index = "2";
-							break L1;
-						}
+					sov = ONLY_CONSTRUCTION;
+				} else {
+					if(isState(javaClass.getSubClasses())) {
+						sov = doMoreAnalysis(javaClass, SUB_NO_BIZ_METHOD, SUB_STATE_SUPER_STATE, SUB_STATE_NOT_PR, SUB_STATE_IS_PR);
+					} else if(isState(javaClass.getSupers())) {
+						sov = doMoreAnalysis(javaClass, SUPER_NO_BIZ_METHOD, SUPER_STATE_TWICE, SUPER_STATE_NOT_PR, SUPER_STATE_IS_PR);
+					} else {
+						sov = ServiceOrVO.UNSURE_SERVICE;
 					}
-				}
-				if (type.equals(Unensure_TYPE)) {
-					L2: for (JavaClass superClass : javaClass.getSupers()) {
-						if (superClass.isState()) {
-							type = VO_TYPE;
-							index = "3";
-							break L2;
-						}
-					}
-				}
-				if (type.equals(Unensure_TYPE)) {
-					type = Service_TYPE;
-					index = "4";
 				}
 			} else {
-				type = VO_TYPE;
-				index = "5";
-			}
-
-			if (type.equals(VO_TYPE) && !ensure_VO_TYPE) {
-
-				boolean haveBusinessMethod = false;
-				O: for (Method method : javaClass.getMethods()) {
-					if (!method.isConstruction() && !method.getName().startsWith("get")
-							&& !method.getName().startsWith("set")) {
-						haveBusinessMethod = true;
-						break O;
-					}
-				}
-				if (!haveBusinessMethod) {
-					type = VO_TYPE;
-					index += "6";
-					ensure_VO_TYPE = true;
-				}
-
-				if (!ensure_VO_TYPE) {
-					L1: for (JavaClass superClass : javaClass.getSupers()) {
-						if (superClass.isState()) {
-							type = VO_TYPE;
-							index += "7";
-							ensure_VO_TYPE = true;
-							break L1;
-						}
-					}
-				}
-
-				if (!ensure_VO_TYPE) {
-					boolean isParamRelation = false;
-					M: for (JavaClassRelationItem item : javaClass.getCaItems()) {
-						if (item.getType() instanceof ParamRelation) {
-							isParamRelation = true;
-							break M;
-						}
-					}
-					if (!isParamRelation) {
-						type = Service_TYPE;
-						index += "9";
-					} else {
-						type = VO_TYPE;
-						index += "10";
-						ensure_VO_TYPE = true;
-					}
-				}
+				sov = doMoreAnalysis(javaClass, UNSURE_NO_BIZ_METHOD, UNSURE_SUPER_STATE, UNSURE_NOT_PR, UNSURE_IS_PR);
 			}
 
 			this.printTable("类名", javaClass.getName());
-			this.printTable("类型", type + index);
+			this.printTable("类型", sov.getType() + sov.getIndex());
 		}
+	}
+	
+	private boolean isState(Collection<JavaClass> collection) {
+		for (JavaClass javaClass : collection) {
+			if (javaClass.isState()) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	private ServiceOrVO doMoreAnalysis(JavaClass javaClass, ServiceOrVO s1, ServiceOrVO s2, ServiceOrVO s3, ServiceOrVO s4) {
+		if (!hasBizMethod(javaClass.getMethods())) {
+			return s1;
+		} else {
+			if(isState(javaClass.getSupers())) {
+				return s2;
+			} else {
+				if(isParamRelation(javaClass.getCaItems())) {
+					return s3;
+				} else {
+					return s4;
+				}
+			}
+		}
+	}
+	
+	private boolean hasBizMethod(Collection<Method> methods) {
+		for (Method method : methods) {
+			if (!method.isConstruction() && !method.getName().startsWith("get")
+					&& !method.getName().startsWith("set")) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	private boolean isParamRelation(Collection<JavaClassRelationItem> items) {
+		for (JavaClassRelationItem item : items) {
+			if (item.getType() instanceof ParamRelation) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/cooper-util/src/main/java/jdepend/util/analyzer/element/helper/ServiceOrVO.java
+++ b/cooper-util/src/main/java/jdepend/util/analyzer/element/helper/ServiceOrVO.java
@@ -9,8 +9,6 @@ import static jdepend.util.analyzer.element.helper.ServiceOrVOType.*;
 
 public enum ServiceOrVO {
 	
-	INIT(UNSURE, false, ""),
-	
 	ONLY_CONSTRUCTION(VO, true, "1"),
 	
 	SUB_NO_BIZ_METHOD(VO, true, "26"),

--- a/cooper-util/src/main/java/jdepend/util/analyzer/element/helper/ServiceOrVO.java
+++ b/cooper-util/src/main/java/jdepend/util/analyzer/element/helper/ServiceOrVO.java
@@ -1,0 +1,66 @@
+/* 
+ * @author Hinex
+ * @date 2015-5-8 13:12:15
+ */
+
+package jdepend.util.analyzer.element.helper;
+
+import static jdepend.util.analyzer.element.helper.ServiceOrVOType.*;
+
+public enum ServiceOrVO {
+	
+	INIT(UNSURE, false, ""),
+	
+	ONLY_CONSTRUCTION(VO, true, "1"),
+	
+	SUB_NO_BIZ_METHOD(VO, true, "26"),
+	
+	SUB_STATE_SUPER_STATE(VO, true, "27"),
+	
+	SUB_STATE_NOT_PR(SERVICE, false, "29"),
+	
+	SUB_STATE_IS_PR(VO, true, "210"),
+	
+	SUPER_NO_BIZ_METHOD(VO, true, "36"),
+	
+	SUPER_STATE_TWICE(VO, true, "37"),
+	
+	SUPER_STATE_NOT_PR(SERVICE, false, "39"),
+	
+	SUPER_STATE_IS_PR(VO, true, "310"),
+	
+	UNSURE_SERVICE(SERVICE, false, "4"),
+	
+	UNSURE_NO_BIZ_METHOD(VO, true, "56"),
+	
+	UNSURE_SUPER_STATE(VO, true, "57"),
+	
+	UNSURE_NOT_PR(SERVICE, false, "59"),
+	
+	UNSURE_IS_PR(VO, true, "510");
+	
+	private ServiceOrVOType type;
+	
+	private boolean ensureVO;
+	
+	private String index;
+	
+	private ServiceOrVO(ServiceOrVOType type, boolean ensureVO, String index) {
+		this.type = type;
+		this.ensureVO = ensureVO;
+		this.index = index;
+	}
+
+	public ServiceOrVOType getType() {
+		return type;
+	}
+
+	public boolean isEnsureVO() {
+		return ensureVO;
+	}
+
+	public String getIndex() {
+		return index;
+	}
+	
+}

--- a/cooper-util/src/main/java/jdepend/util/analyzer/element/helper/ServiceOrVOType.java
+++ b/cooper-util/src/main/java/jdepend/util/analyzer/element/helper/ServiceOrVOType.java
@@ -1,0 +1,23 @@
+/* 
+ * @author Hinex
+ * @date 2015-5-8 13:15:10
+ */
+
+package jdepend.util.analyzer.element.helper;
+
+public enum ServiceOrVOType {
+	
+	SERVICE("Service"), VO("VO"), UNSURE("不确定");
+	
+	private String value;
+	
+	private ServiceOrVOType(String value) {
+		this.value = value;
+	}
+	
+	@Override
+	public String toString() {
+		return this.value;
+	}
+
+}


### PR DESCRIPTION
做了如下工作：
1. 重构了 `IdentifyJavaClassType.java` 中的 `doSearch` 方法
2. 针对类只存在构造函数的情况补充了多个构造函数的判断

可能存在的问题：
1. 没有测试代码无法验证重构的正确性
2. `researchServiceOrVO` 方法中对状态的判断部分应该还有可以改进的空间
3. `hasBizMethod` 方法可能会对只包含类似 `isBooleanVar()` 等的 `VO` 产生误判
